### PR TITLE
Evaluate s6-linux-init arguments before execing into s6-linux-init-telinit

### DIFF
--- a/src/init/s6-linux-init.c
+++ b/src/init/s6-linux-init.c
@@ -143,12 +143,6 @@ int main (int argc, char const **argv, char const *const *envp)
   stralloc envmodifs = STRALLOC_ZERO ;
   PROG = "s6-linux-init" ;
 
-  if (getpid() != 1)
-  {
-    argv[0] = S6_LINUX_INIT_BINPREFIX "s6-linux-init-telinit" ;
-    xexec_e(argv, envp) ;
-  }
-
   {
     subgetopt l = SUBGETOPT_ZERO ;
     for (;;)
@@ -171,6 +165,12 @@ int main (int argc, char const **argv, char const *const *envp)
       }
     }
     argc -= l.ind ; argv += l.ind ;
+  }
+
+  if (getpid() != 1)
+  {
+    argv[0] = S6_LINUX_INIT_BINPREFIX "s6-linux-init-telinit" ;
+    xexec_e(argv, envp) ;
   }
 
   if (fcntl(1, F_GETFD) < 0) hasconsole = 0 ;


### PR DESCRIPTION
Execing into s6-linux-init-telinit results in the USAGE message of
s6-linux-init to be shown if it is actually running as pid1 already,
which makes it significantly less usefull. By parsing the command line
first, we allow the user to use arguments like -h to produce
the acutally expected usage message of s6-linux-init instead of
s6-linux-init-telinit.