### PR TITLE
s6-linux-init-umountall: If umount fails, attempt to remount read-only

### DIFF
--- a/doc/s6-linux-init-umountall.html
+++ b/doc/s6-linux-init-umountall.html
@@ -32,8 +32,8 @@
 <ul>
  <li> <tt>s6-linux-init-umountall</tt> unmounts all filesystems according to <tt>/proc/mounts</tt>.
 It processes <tt>/proc/mounts</tt> in the reverse order, starting with the most recently mounted
-partition and ending with the root filesystem ("unmounting" the root filesystem means remounting
-it read-only). </li>
+partition and ending with the root filesystem. If a filesystem fails to unmount, it will be
+remounted read-only.</li>
  <li> It makes an exception for the first instances of <em>devtmpfs</em>, <em>proc</em>
 and <em>sysfs</em> filesystem types, but not for later instances. In other words: it
 does not attempt to unmount <tt>/dev</tt>, <tt>/proc</tt> and <tt>/sys</tt>, but it

--- a/src/misc/s6-linux-init-umountall.c
+++ b/src/misc/s6-linux-init-umountall.c
@@ -53,10 +53,11 @@ int main (int argc, char const *const *argv)
   endmntent(fp) ;
 
   while (line--)
-    if (umount(sa.s + mountpoints[line]) == -1)
+    if (umount(sa.s + mountpoints[line]) == -1 &&
+        mount(0, sa.s + mountpoints[line], 0, MS_REMOUNT | MS_RDONLY, 0) == -1)
     {
       e++ ;
-      strerr_warnwu2sys("umount ", sa.s + mountpoints[line]) ;
+      strerr_warnwu2sys("umount and remount ro ", sa.s + mountpoints[line]) ;
     }
   stralloc_free(&sa) ;
   return e ;


### PR DESCRIPTION
The umount will fail for the filesystem that s6 is being run out of, if that is not the root filesystem. This will lead to the system rebooting with that filesystem mounted read-write, requiring it to be recovered/checked on the next boot. Fix it by remounting filesystems read-only if umount fails.